### PR TITLE
remove fuzzyset.js line from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/amjacobowitz/SmartText#readme",
   "dependencies": {
-    "fuzzyset.js",
     "body-parser": "^1.13.3",
     "ejs": "^2.3.3",
     "express": "^4.13.3",


### PR DESCRIPTION
@adamfluke I pulled down a fresh copy of the repo cuz of some problems and i couldn't npm install because of this line

npm ERR! Unexpected token ',' at 30:18
npm ERR!     "fuzzyset.js",

in packages.json so i removed it
